### PR TITLE
fix(FileAnalyzer): update regex for inheriting from more than two contracts

### DIFF
--- a/lib/fileAnalyzer.ts
+++ b/lib/fileAnalyzer.ts
@@ -130,7 +130,7 @@ export class FileAnalyzer {
    */
   analyzeExports(contents: string): FileAnalyzerExportsResult[] {
     const exportRegex = /(contract|library|interface)\s+([a-zA-Z_$][a-zA-Z_$0-9]*)\s*([\s\S]*?)\{/g;
-    const isRegex = /^is\s*[a-zA-Z_$][a-zA-Z_$0-9]*(.[a-zA-Z_$][a-zA-Z_$0-9]*)?(\([\s\S]*?\))?(,\s*?[a-zA-Z_$][a-zA-Z_$0-9]*(.[a-zA-Z_$][a-zA-Z_$0-9]*)?(\([\s\S]*?\))?)?\s*$/;
+    const isRegex = /^is\s*[a-zA-Z_$][a-zA-Z_$0-9]*(.[a-zA-Z_$][a-zA-Z_$0-9]*)?(\([\s\S]*?\))?(,\s*?[a-zA-Z_$][a-zA-Z_$0-9]*(.[a-zA-Z_$][a-zA-Z_$0-9]*)?(\([\s\S]*?\))?)*\s*$/;
     const results = [];
     let group: RegExpExecArray;
     while ((group = exportRegex.exec(contents))) {


### PR DESCRIPTION
The regex for `is` inheritance works when inheriting from up to two contracts, but fails for three or more contracts. Example:

```
contract Test123 is Test1, Test2, Test3 {}
```