### PR TITLE
Develop

### DIFF
--- a/lib/antlr/visitors/exportVisitor.ts
+++ b/lib/antlr/visitors/exportVisitor.ts
@@ -1,5 +1,6 @@
 import { CharStreams, CommonTokenStream, Token } from 'antlr4ts';
 import { ParseTreeWalker } from 'antlr4ts/tree/ParseTreeWalker';
+import { ExportType } from '../../types';
 import { SolidityLexer } from '../generated/SolidityLexer';
 import { SolidityListener } from '../generated/SolidityListener';
 import {
@@ -10,7 +11,7 @@ import {
   SourceUnitContext,
   StructDefinitionContext,
 } from '../generated/SolidityParser';
-import { ExportType, ExportVisitResult, VisitCallback } from './types';
+import { ExportVisitResult, VisitCallback } from './types';
 
 const HIDDEN_CHANNEL = 1;
 
@@ -69,7 +70,7 @@ export class SolidityExportVisitor {
       this.#comments.length &&
       this.#comments[0].stopIndex < visitResult.end
     ) {
-      const skipped = this.#comments.shift();
+      this.#comments.shift();
     }
   }
 
@@ -92,7 +93,7 @@ export class SolidityExportVisitor {
       end: comment.stopIndex,
       is: null,
       name: `Comment#${comment.startIndex}`,
-      type: 'comment',
+      type: ExportType.comment,
     };
   }
 }
@@ -175,7 +176,7 @@ class ExportVisitor implements SolidityListener {
       start,
       end,
       abstract: false,
-      type: 'struct',
+      type: ExportType.struct,
       body: {
         start: bodyStart + 1,
         end,
@@ -211,7 +212,7 @@ class ExportVisitor implements SolidityListener {
       start,
       end,
       abstract: false,
-      type: 'enum',
+      type: ExportType.enum,
       body: {
         start: bodyStart + 1,
         end,

--- a/lib/antlr/visitors/exportVisitor.ts
+++ b/lib/antlr/visitors/exportVisitor.ts
@@ -1,4 +1,4 @@
-import { CharStreams, CommonTokenStream } from 'antlr4ts';
+import { CharStreams, CommonTokenStream, Token } from 'antlr4ts';
 import { ParseTreeWalker } from 'antlr4ts/tree/ParseTreeWalker';
 import { SolidityLexer } from '../generated/SolidityLexer';
 import { SolidityListener } from '../generated/SolidityListener';
@@ -12,9 +12,12 @@ import {
 } from '../generated/SolidityParser';
 import { ExportType, ExportVisitResult, VisitCallback } from './types';
 
+const HIDDEN_CHANNEL = 1;
+
 export class SolidityExportVisitor {
   #inputContent: string;
   #antlrTree: SourceUnitContext;
+  #comments: Token[] = [];
   constructor(inputContent: string) {
     this.#inputContent = inputContent;
 
@@ -23,11 +26,74 @@ export class SolidityExportVisitor {
     const tokens = new CommonTokenStream(lexer);
     const parser = new SolidityParser(tokens);
     this.#antlrTree = parser.sourceUnit();
+
+    this.#comments = tokens
+      .getRange(0, tokens.size)
+      .filter((t) => t.channel === HIDDEN_CHANNEL);
   }
 
   visit(onVisit: VisitCallback<ExportVisitResult>) {
-    const listener: SolidityListener = new ExportVisitor(onVisit);
+    const listener: SolidityListener = new ExportVisitor((visitResult) => {
+      this.onVisit(visitResult, onVisit);
+    });
     ParseTreeWalker.DEFAULT.walk(listener, this.#antlrTree);
+    this.flushComments(onVisit);
+  }
+
+  private onVisit(
+    visitResult: ExportVisitResult,
+    onVisit: VisitCallback<ExportVisitResult>,
+  ) {
+    if (!this.#comments.length) {
+      return onVisit(visitResult);
+    }
+    this.emitCommentsBefore(visitResult, onVisit);
+    onVisit(visitResult);
+  }
+
+  private emitCommentsBefore(
+    visitResult: ExportVisitResult,
+    onVisit: VisitCallback<ExportVisitResult>,
+  ) {
+    while (
+      this.#comments.length &&
+      this.#comments[0].startIndex < visitResult.start
+    ) {
+      const comment = this.#comments.shift();
+      if (!comment) {
+        continue;
+      }
+      onVisit(this.buildComment(comment));
+    }
+    while (
+      this.#comments.length &&
+      this.#comments[0].stopIndex < visitResult.end
+    ) {
+      const skipped = this.#comments.shift();
+    }
+  }
+
+  private flushComments(onVisit: VisitCallback<ExportVisitResult>) {
+    if (!this.#comments.length) {
+      return;
+    }
+
+    this.#comments.forEach((comment) => onVisit(this.buildComment(comment)));
+  }
+
+  private buildComment(comment: Token): ExportVisitResult {
+    return {
+      abstract: false,
+      body: {
+        start: comment.startIndex,
+        end: comment.stopIndex,
+      },
+      start: comment.startIndex,
+      end: comment.stopIndex,
+      is: null,
+      name: `Comment#${comment.startIndex}`,
+      type: 'comment',
+    };
   }
 }
 

--- a/lib/antlr/visitors/types.ts
+++ b/lib/antlr/visitors/types.ts
@@ -14,7 +14,7 @@ export interface ImportVisitNamedImport {
   as: string | null
 }
 
-export type ExportType = 'contract' | 'library' | 'interface' | 'struct' | 'enum';
+export type ExportType = 'contract' | 'library' | 'interface' | 'struct' | 'enum' | 'comment';
 
 export interface ExportVisitResult extends RangeVisitResult {
   abstract: boolean;

--- a/lib/antlr/visitors/types.ts
+++ b/lib/antlr/visitors/types.ts
@@ -1,3 +1,5 @@
+import { ExportType } from '../../types';
+
 export interface RangeVisitResult {
   start: number;
   end: number;
@@ -6,21 +8,19 @@ export interface RangeVisitResult {
 export interface ImportVisitResult extends RangeVisitResult {
   filename: string;
   globalRename: string | null;
-  namedImports: ImportVisitNamedImport[] | null
+  namedImports: ImportVisitNamedImport[] | null;
 }
 
 export interface ImportVisitNamedImport {
   name: string;
-  as: string | null
+  as: string | null;
 }
-
-export type ExportType = 'contract' | 'library' | 'interface' | 'struct' | 'enum' | 'comment';
 
 export interface ExportVisitResult extends RangeVisitResult {
   abstract: boolean;
   type: ExportType;
   name: string;
-  body: RangeVisitResult,
+  body: RangeVisitResult;
   is: RangeVisitResult | null;
 }
 

--- a/lib/exportsAnalyzer.ts
+++ b/lib/exportsAnalyzer.ts
@@ -1,5 +1,4 @@
 import Debug from 'debug';
-import parser from 'solidity-parser-antlr';
 import { SolidityExportVisitor } from './antlr/visitors/exportVisitor';
 import { ExportType } from './types';
 

--- a/lib/exportsAnalyzer.ts
+++ b/lib/exportsAnalyzer.ts
@@ -1,11 +1,12 @@
 import Debug from 'debug';
 import parser from 'solidity-parser-antlr';
 import { SolidityExportVisitor } from './antlr/visitors/exportVisitor';
+import { ExportType } from './types';
 
 const error = Debug('sol-merger:error');
 
 export interface ExportsAnalyzerResult {
-  type: 'contract' | 'library' | 'interface' | 'struct' | 'enum' | 'comment';
+  type: ExportType;
   name: string;
   is: string;
   body: string;
@@ -33,7 +34,9 @@ export class ExportsAnalyzer {
           type: e.type,
           name: e.name,
           body: this.contents.substring(e.body.start, e.body.end + 1).trim(),
-          is: e.is ? this.contents.substring(e.is.start, e.is.end + 1).trimLeft() : '',
+          is: e.is
+            ? this.contents.substring(e.is.start, e.is.end + 1).trimLeft()
+            : '',
         });
       });
       return results;

--- a/lib/exportsAnalyzer.ts
+++ b/lib/exportsAnalyzer.ts
@@ -5,7 +5,7 @@ import { SolidityExportVisitor } from './antlr/visitors/exportVisitor';
 const error = Debug('sol-merger:error');
 
 export interface ExportsAnalyzerResult {
-  type: 'contract' | 'library' | 'interface' | 'struct' | 'enum';
+  type: 'contract' | 'library' | 'interface' | 'struct' | 'enum' | 'comment';
   name: string;
   is: string;
   body: string;

--- a/lib/exportsAnalyzer.ts
+++ b/lib/exportsAnalyzer.ts
@@ -5,6 +5,7 @@ import { ExportType } from './types';
 const error = Debug('sol-merger:error');
 
 export interface ExportsAnalyzerResult {
+  abstact: boolean;
   type: ExportType;
   name: string;
   is: string;
@@ -30,6 +31,7 @@ export class ExportsAnalyzer {
       const visitor = new SolidityExportVisitor(this.contents);
       visitor.visit((e) => {
         results.push({
+          abstact: e.abstract,
           type: e.type,
           name: e.name,
           body: this.contents.substring(e.body.start, e.body.end + 1).trim(),

--- a/lib/fileAnalyzer.ts
+++ b/lib/fileAnalyzer.ts
@@ -16,6 +16,10 @@ export class FileAnalyzer {
     newName: string | null,
     globalRenames: RegistredImport[],
   ): string {
+    if (e.type === 'comment') {
+      return e.body;
+    }
+
     let is = e.is;
     if (is) {
       globalRenames.forEach((i) => {

--- a/lib/fileAnalyzer.ts
+++ b/lib/fileAnalyzer.ts
@@ -39,7 +39,9 @@ export class FileAnalyzer {
         }
       });
     }
-    return `${e.type} ${newName || e.name} ${is}${e.body}`;
+
+    const abstract = e.abstact ? 'abstract ' : '';
+    return `${abstract}${e.type} ${newName || e.name} ${is}${e.body}`;
   }
   /**
    * Filename to read to get contract data

--- a/lib/fileAnalyzer.ts
+++ b/lib/fileAnalyzer.ts
@@ -2,7 +2,8 @@ import fs from 'fs-extra';
 import stripComments from 'strip-json-comments';
 import { ExportsAnalyzer, ExportsAnalyzerResult } from './exportsAnalyzer';
 import { RegistredImport } from './importRegistry';
-import { ImportsAnalyzerResult, ImportsAnalyzer } from './importsAnalyzer';
+import { ImportsAnalyzer, ImportsAnalyzerResult } from './importsAnalyzer';
+import { ExportType } from './types';
 
 export class FileAnalyzer {
   filename: string;
@@ -16,7 +17,7 @@ export class FileAnalyzer {
     newName: string | null,
     globalRenames: RegistredImport[],
   ): string {
-    if (e.type === 'comment') {
+    if (e.type === ExportType.comment) {
       return e.body;
     }
 

--- a/lib/importsAnalyzer.ts
+++ b/lib/importsAnalyzer.ts
@@ -1,4 +1,3 @@
-import parser from 'solidity-parser-antlr';
 import { Utils } from './utils';
 import { SolidityImportVisitor } from './antlr/visitors/importVisitor';
 import { ImportVisitResult } from './antlr/visitors/types';
@@ -38,17 +37,12 @@ export class ImportsAnalyzer {
    */
   analyzeImports(): ImportsAnalyzerResult[] {
     const imports: ImportsAnalyzerResult[] = [];
-    const ast = Utils.getAstNode(this.contents);
 
     const importDirectives: ImportVisitResult[] = [];
     const visitor = new SolidityImportVisitor(this.contents);
     visitor.visit((i) => {
       importDirectives.push(i);
     });
-
-    if (!ast) {
-      return [];
-    }
 
     for (const importDirective of importDirectives) {
       const analyzedImport = this.analyzeImport(importDirective);
@@ -65,7 +59,9 @@ export class ImportsAnalyzer {
    * 3. Extract filename from import
    *
    */
-  private analyzeImport(importVisitResult: ImportVisitResult): ImportsAnalyzerResult {
+  private analyzeImport(
+    importVisitResult: ImportVisitResult,
+  ): ImportsAnalyzerResult {
     return {
       file: importVisitResult.filename,
       globalRenameImport: importVisitResult.globalRename,

--- a/lib/merger.ts
+++ b/lib/merger.ts
@@ -64,7 +64,11 @@ export class Merger {
       await this.init(file);
     }
     if (this.importRegistry.isImportProcessed(parentImport?.importStatement)) {
-      debug('  %s Import statement already processed: %s', '⚠', parentImport?.importStatement);
+      debug(
+        '  %s Import statement already processed: %s',
+        '⚠',
+        parentImport?.importStatement,
+      );
       return '';
     }
     if (parentImport) {
@@ -150,6 +154,9 @@ export class Merger {
     );
 
     const shouldBeImported = (exportName: string) => {
+      if (e.type === 'comment' && (isAllImport || isRenameGlobalImport)) {
+        return true;
+      }
       return (
         isAllImport ||
         isRenameGlobalImport ||
@@ -169,7 +176,7 @@ export class Merger {
       analyzedFile.filename,
       e.name,
       rename,
-    );
+    )
     if (isImported) {
       debug('%s Already imported: %s %s', '⚠', e.name, analyzedFile.filename);
       return [];

--- a/lib/merger.ts
+++ b/lib/merger.ts
@@ -5,6 +5,7 @@ import { ExportsAnalyzerResult } from './exportsAnalyzer';
 import { FileAnalyzer, FileAnalyzerResult } from './fileAnalyzer';
 import { ImportsRegistry } from './importRegistry';
 import { ImportsAnalyzer, ImportsAnalyzerResult } from './importsAnalyzer';
+import { ExportType } from './types';
 import { Utils } from './utils';
 
 const error = Debug('sol-merger:error');
@@ -154,7 +155,10 @@ export class Merger {
     );
 
     const shouldBeImported = (exportName: string) => {
-      if (e.type === 'comment' && (isAllImport || isRenameGlobalImport)) {
+      if (
+        e.type === ExportType.comment &&
+        (isAllImport || isRenameGlobalImport)
+      ) {
         return true;
       }
       return (
@@ -176,7 +180,7 @@ export class Merger {
       analyzedFile.filename,
       e.name,
       rename,
-    )
+    );
     if (isImported) {
       debug('%s Already imported: %s %s', '⚠', e.name, analyzedFile.filename);
       return [];

--- a/lib/merger.ts
+++ b/lib/merger.ts
@@ -13,6 +13,7 @@ const debug = Debug('sol-merger:debug');
 
 export class Merger {
   delimeter: string = this.options.delimeter || '\n\n';
+  commentsDelimeter: string = this.options.commentsDelimeter || '\n';
   removeComments: boolean;
 
   private importRegistry: ImportsRegistry;
@@ -106,7 +107,11 @@ export class Merger {
 
     const fileExports = await this.processExports(analyzedFile, parentImport);
     for (const e of fileExports) {
-      result += e + this.delimeter;
+      if (this.isComment(e)) {
+        result += e + this.commentsDelimeter;
+      } else {
+        result += e + this.delimeter;
+      }
     }
 
     return result.trimRight();
@@ -224,9 +229,14 @@ export class Merger {
       });
     });
   }
+
+  private isComment(str: string) {
+    return str.startsWith('//') || str.startsWith('/*');
+  }
 }
 
 export interface SolMergerOptions {
   delimeter?: string;
   removeComments?: boolean;
+  commentsDelimeter?: string;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,8 @@
+export enum ExportType {
+  contract = 'contract',
+  library = 'library',
+  interface = 'interface',
+  struct = 'struct',
+  enum = 'enum',
+  comment = 'comment'
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,15 +1,5 @@
-import parser, { ASTNode } from 'solidity-parser-antlr';
-
 export class Utils {
   static isRelative(file: string) {
     return file.startsWith('.');
-  }
-
-  static getAstNode(contents: string): ASTNode | null {
-    try {
-      return parser.parse(contents, { loc: true, range: true });
-    } catch {
-      return null;
-    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1040,11 +1040,6 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
-    "solidity-parser-antlr": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz",
-      "integrity": "sha512-4jtxasNGmyC0midtjH/lTFPZYvTTUMy6agYcF+HoMnzW8+cqo3piFrINb4ZCzpPW+7tTVFCGa5ubP34zOzeuMg=="
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "debug": "^4.1.1",
     "fs-extra": "^8.0.1",
     "glob": "^7.1.2",
-    "solidity-parser-antlr": "^0.4.11",
     "strip-json-comments": "^3.0.1"
   },
   "pre-commit": [

--- a/test/compiled/AbstractContract.sol
+++ b/test/compiled/AbstractContract.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.6.0;
+
+
+abstract contract Feline {
+    function utterance() public virtual returns (bytes32);
+}
+
+contract Cat is Feline {
+    function utterance() public override returns (bytes32) { return "miaow"; }
+}

--- a/test/compiled/ContactWithKeywordsInsideString.sol
+++ b/test/compiled/ContactWithKeywordsInsideString.sol
@@ -20,6 +20,8 @@ contract ConflictingInheritance {
 
 }
 
+// This contract will not be detected
+
 contract B {
     uint private b;
 

--- a/test/compiled/ContactWithKeywordsInsideString.sol
+++ b/test/compiled/ContactWithKeywordsInsideString.sol
@@ -21,7 +21,6 @@ contract ConflictingInheritance {
 }
 
 // This contract will not be detected
-
 contract B {
     uint private b;
 

--- a/test/compiled/GlobalComments.sol
+++ b/test/compiled/GlobalComments.sol
@@ -1,0 +1,21 @@
+pragma solidity 0.6.0;
+
+
+/*
+ * Multiline Comment Before
+ */
+
+// This is not included Before
+
+contract MyContract {
+    // This is included
+    function myFunction() {
+        // This is included
+    }
+}
+
+// This is not included After
+
+/*
+ * Multiline Comment After
+ */

--- a/test/compiled/GlobalComments.sol
+++ b/test/compiled/GlobalComments.sol
@@ -4,9 +4,7 @@ pragma solidity 0.6.0;
 /*
  * Multiline Comment Before
  */
-
 // This is not included Before
-
 contract MyContract {
     // This is included
     function myFunction() {
@@ -15,7 +13,6 @@ contract MyContract {
 }
 
 // This is not included After
-
 /*
  * Multiline Comment After
  */

--- a/test/contracts/AbstractContract.sol
+++ b/test/contracts/AbstractContract.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.6.0;
+
+abstract contract Feline {
+    function utterance() public virtual returns (bytes32);
+}
+
+contract Cat is Feline {
+    function utterance() public override returns (bytes32) { return "miaow"; }
+}

--- a/test/contracts/Enum.sol
+++ b/test/contracts/Enum.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.0;
 
-enum State1 { Created1, Locked1, Inactive1 } // Enum
+enum State1 { Created1, Locked1, Inactive1 }
 
 contract Purchase {
     enum State { Created, Locked, Inactive } // Enum

--- a/test/contracts/GlobalComments.sol
+++ b/test/contracts/GlobalComments.sol
@@ -1,0 +1,16 @@
+pragma solidity 0.6.0;
+
+/*
+ * Multiline Comment Before
+ */
+// This is not included Before
+contract MyContract {
+    // This is included
+    function myFunction() {
+        // This is included
+    }
+}
+// This is not included After
+/*
+ * Multiline Comment After
+ */

--- a/test/exportsAnalyzer.spec.ts
+++ b/test/exportsAnalyzer.spec.ts
@@ -33,32 +33,37 @@ describe('ExportsAnalyzer', () => {
       const exports = exportsAnalyzer.analyzeExports();
 
       assert.deepEqual(exports, [
-        { type: 'contract', name: 'A', is: '', body: '{ }' },
+        { abstact: false, type: 'contract', name: 'A', is: '', body: '{ }' },
         {
+          abstact: false,
           type: 'contract',
           name: 'B',
           is: 'is A ',
           body: '{\n          // some body here...\n        }',
         },
         {
+          abstact: false,
           type: 'library',
           name: 'L',
           is: '',
           body: '{\n          // l...\n        }',
         },
         {
+          abstact: false,
           type: 'interface',
           name: 'B',
           is: '',
           body: '{\n          // i...\n        }',
         },
         {
+          abstact: false,
           body: '{\n          uint weight;\n          bool voted;\n        }',
           is: '',
           name: 'S',
           type: 'struct',
         },
         {
+          abstact: false,
           body:
             '{\n          Created,\n          Locked,\n          Inactive\n        }',
           is: '',
@@ -78,12 +83,14 @@ describe('ExportsAnalyzer', () => {
 
       assert.deepEqual(exports, [
         {
+          abstact: false,
           body: '// Some contracts without exports',
           is: '',
           name: 'Comment#9',
           type: 'comment',
         },
         {
+          abstact: false,
           body: '// Some contract text that is not required here',
           is: '',
           name: 'Comment#52',

--- a/test/exportsAnalyzer.spec.ts
+++ b/test/exportsAnalyzer.spec.ts
@@ -68,11 +68,33 @@ describe('ExportsAnalyzer', () => {
       ]);
     });
 
-    it('should return empty array if there are no exports', () => {
+    it('should return comments array', () => {
       const exportsAnalyzer = new ExportsAnalyzer(`
         // Some contracts without exports
 
         // Some contract text that is not required here
+      `);
+      const exports = exportsAnalyzer.analyzeExports();
+
+      assert.deepEqual(exports, [
+        {
+          body: '// Some contracts without exports',
+          is: '',
+          name: 'Comment#9',
+          type: 'comment',
+        },
+        {
+          body: '// Some contract text that is not required here',
+          is: '',
+          name: 'Comment#52',
+          type: 'comment',
+        },
+      ]);
+    });
+
+    it('should return empty array if there are no exports', () => {
+      const exportsAnalyzer = new ExportsAnalyzer(`
+
       `);
       const exports = exportsAnalyzer.analyzeExports();
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -87,6 +87,10 @@ describe('Solidity Merger', () => {
     await testFile('GlobalComments');
   });
 
+  it('should compile abstract contracts', async () => {
+    await testFile('AbstractContract');
+  });
+
   it('should compile file without imports and exports (empty content)', async () => {
     const merger = new Merger();
     const file = path.join(__dirname, `/contracts/EmptyFile.sol`);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -83,6 +83,10 @@ describe('Solidity Merger', () => {
     await testFile('ImportStruct');
   });
 
+  it('should compile while when importing the struct', async () => {
+    await testFile('GlobalComments');
+  });
+
   it('should compile file without imports and exports (empty content)', async () => {
     const merger = new Merger();
     const file = path.join(__dirname, `/contracts/EmptyFile.sol`);


### PR DESCRIPTION
* Add support for `abstract` contracts
* Refactor `ExportType` to enum
* Remove `solidity-parser-antlr` dependency

Relates #19 