### PR TITLE
feat(sol-merger): add support for additional roots for resolving contracts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from node:16-stretch
+FROM node:16-stretch
 
 WORKDIR /sol-merger
 COPY test-cli.sh test-docker-entrypoint.sh package.json package-lock.json tsconfig.json tsconfig.app.json tslint.json ./

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ### Build status
+
 ![Build status](https://github.com/RyuuGan/sol-merger/actions/workflows/node.js.yml/badge.svg)
 
 ### Quick Usage
@@ -7,7 +8,7 @@
 const { merge } = require('sol-merger');
 
 // Get the merged code as a string
-const mergedCode = await merge("./contracts/MyContract.sol");
+const mergedCode = await merge('./contracts/MyContract.sol');
 // Print it out or write it to a file etc.
 console.log(mergedCode);
 ```
@@ -29,7 +30,7 @@ Then add following line to your `package.json`.
 {
   "scripts": {
     "build-contracts": "sol-merger \"./contracts/*.sol\" ./build"
-  },
+  }
 }
 ```
 
@@ -45,6 +46,7 @@ change this behaviour by specifying `--append` option:
 sol-merger --append _me "./contracts/*.sol"
 sol-merger -a _me "./contracts/*.sol"
 ```
+
 You may need to use `npm run` to invoke the program standalone, as in `npm run sol-merger`.
 
 You can also get help via `--help` command
@@ -80,6 +82,31 @@ sol-merger --export-plugin sol-merger/lib/plugins/SPDXLicenseRemovePlugin.js "te
 ```
 
 Note that file extension is required for plugin to be loaded.
+
+# Additional root folders for searching contracts
+
+By default, `sol-merger` only searches for contracts in the `node_modules` folder.
+However, you can include additional root folders to search for contracts.
+This can be done by passing a CLI argument or a parameter through the code.
+
+If additional root folders are specified, `sol-merger` will first search for
+the contract in the `node_modules` folder and then in the additional root folders.
+Multiple folders can be included by passing a CLI argument multiple times.
+
+Example of usage in CLI:
+
+```sh
+sol-merger --additional-root "./test/contracts/imports" "test/contracts/ImportWithAdditionalRoot.sol" compiled
+```
+
+Example of usage in code:
+
+```ts
+const merger = new Merger({
+  delimeter: '\n\n',
+  additionalRoots: ['./test/contracts/imports'],
+});
+```
 
 # Debuging
 

--- a/bin/sol-merger.ts
+++ b/bin/sol-merger.ts
@@ -24,7 +24,13 @@ program
   .option(
     '-p, --export-plugin [pathToPlugin]',
     `Add post processor for exports`,
-    collectExportPluginOption,
+    collectArrayOptions,
+    [],
+  )
+  .option(
+    '-r, --additional-root [pathToRoot]',
+    `Add additional root to search contracts in`,
+    collectArrayOptions,
     [],
   )
   .arguments('<glob> [outputDir]')
@@ -49,8 +55,9 @@ if (outputDir) {
 }
 
 debug('Output directory', outputDir);
-debug('RemoveComments?', program.removeComments);
-debug('ExportPlugins?', program.exportPlugin);
+debug('Remove comments?', program.removeComments);
+debug('Export plugins', program.exportPlugin);
+debug('Additional roots', program.additionalRoot);
 
 glob(
   inputGlob,
@@ -79,6 +86,7 @@ async function execute(err: Error, files: string[]) {
       delimeter: '\n\n',
       removeComments: program.removeComments,
       exportPlugins,
+      additionalRoots: program.additionalRoot,
     });
     let result: string;
     result = await merger.processFile(file, true);
@@ -101,7 +109,7 @@ async function execute(err: Error, files: string[]) {
     .catch(done);
 }
 
-function collectExportPluginOption(value: string, previousValue: string[]) {
+function collectArrayOptions(value: string, previousValue: string[]) {
   return previousValue.concat([value]);
 }
 

--- a/test-cli.sh
+++ b/test-cli.sh
@@ -8,7 +8,10 @@ WITHOUT_COMMENTS=(
 SKIPPED=(
   compiled/EmptyFile.sol
   compiled/LocalImportsWithSPDX.sol
+  compiled/ImportWithAdditionalRoot.sol
 )
+
+PROCESSED_GLOB="test/contracts/!(ImportWithAdditionalRoot).sol"
 
 compareFile() {
   local file="$1";
@@ -30,7 +33,7 @@ compareFile() {
 # Compare files with comments
 
 rm -rf compiled
-sol-merger "test/contracts/*.sol" compiled
+sol-merger "$PROCESSED_GLOB" compiled
 
 echo "Default compilation (with comments)"
 
@@ -49,19 +52,25 @@ done
 # Remove SPDX Plugin
 echo "Compilation with plugins"
 rm -rf compiled
-sol-merger --export-plugin ./dist/lib/plugins/SPDXLicenseRemovePlugin.js "test/contracts/*.sol" compiled
+sol-merger --export-plugin ./dist/lib/plugins/SPDXLicenseRemovePlugin.js "$PROCESSED_GLOB" compiled
 
 compareFile compiled/LocalImportsWithSPDX.sol
 
 rm -rf compiled
-sol-merger --export-plugin SPDXLicenseRemovePlugin "test/contracts/*.sol" compiled
+sol-merger --export-plugin SPDXLicenseRemovePlugin "$PROCESSED_GLOB" compiled
 
 compareFile compiled/LocalImportsWithSPDX.sol
+
+echo "Compilation with --additional-root option"
+rm -rf compiled
+sol-merger --additional-root "./test/contracts/imports" "test/contracts/ImportWithAdditionalRoot.sol" compiled
+
+compareFile compiled/ImportWithAdditionalRoot.sol
 
 # Remove Comments
 echo "Compilation with --remove-comments option"
 rm -rf compiled
-sol-merger --remove-comments "test/contracts/*.sol" compiled
+sol-merger --remove-comments "$PROCESSED_GLOB" compiled
 
 for file in "${WITHOUT_COMMENTS[@]}"
 do

--- a/test/compiled/ImportWithAdditionalRoot.sol
+++ b/test/compiled/ImportWithAdditionalRoot.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.4.11;
+pragma experimental ABIEncoderV2;
+
+
+contract Ownable {
+  address public owner;
+
+  function Ownable() {
+    owner = msg.sender;
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  function transferOwnership(address newOwner) onlyOwner {
+    if (newOwner != address(0)) {
+      owner = newOwner;
+    }
+  }
+
+}
+
+contract MyOwned is Ownable {
+  // Super important comment here
+  string public constant name = "My Owned";
+
+  /**
+   * Super important description here
+   */
+  function MyOwned() {}
+}

--- a/test/contracts/ImportWithAdditionalRoot.sol
+++ b/test/contracts/ImportWithAdditionalRoot.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.11;
+pragma experimental ABIEncoderV2;
+
+import "ownable.sol";
+
+contract MyOwned is Ownable {
+  // Super important comment here
+  string public constant name = "My Owned";
+
+  /**
+   * Super important description here
+   */
+  function MyOwned() {}
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -144,4 +144,19 @@ describe('Solidity Merger', () => {
   it('should compile file with user defined operators (0.8.19 support)', async () => {
     await testFile('UserDefinedOperators');
   });
+
+  it('should compile file with additional roots defined', async () => {
+    await testFile('ImportWithAdditionalRoot', {
+      additionalRoots: ['./test/contracts/imports'],
+    });
+  });
+
+  it('should not compile file without additional roots defined', async () => {
+    try {
+      await testFile('ImportWithAdditionalRoot', {});
+      assert.equal(true, false, 'Should never happen');
+    } catch (e) {
+      assert.isOk(e);
+    }
+  });
 });


### PR DESCRIPTION
This will allow to pass CLI argument or the parameter through the code to pass additional roots while resolving the contracts, similar to the `node_modules`.

Example of usage in CLI:

```sh
sol-merger --additional-root "./test/contracts/imports" "test/contracts/ImportWithAdditionalRoot.sol" compiled
```

Example of usage in code:

```ts
const merger = new Merger({
  delimeter: '\n\n',
  additionalRoots: ['./test/contracts/imports'],
});
```

Closes #67