### PR TITLE
fix(exports): fix calculating export is clause for the contacts

### DIFF
--- a/lib/exportsAnalyzer.ts
+++ b/lib/exportsAnalyzer.ts
@@ -51,7 +51,7 @@ export interface ExportsAnalyzerResultUsingDirective {
 }
 
 export class ExportsAnalyzer {
-  constructor(private contents: string) {}
+  constructor(private contents: string) { }
 
   /**
    * Analyzes all the exports of the file (Contract, Interface, Library)
@@ -97,7 +97,7 @@ export class ExportsAnalyzer {
           name: e.name,
           body: this.contents.substring(e.body.start, e.body.end + 1).trim(),
           is: e.is
-            ? this.contents.substring(e.is.start, e.is.end + 1).trimLeft()
+            ? this.contents.substring(e.is.start, e.is.end).trimLeft() + ' '
             : '',
         });
       });

--- a/test/compiled/ContractWithoutSpaceBeforeBracket.sol
+++ b/test/compiled/ContractWithoutSpaceBeforeBracket.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.8.8;
+
+
+contract B {
+}
+
+contract A is B {
+}

--- a/test/contracts/ContractWithoutSpaceBeforeBracket.sol
+++ b/test/contracts/ContractWithoutSpaceBeforeBracket.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.8.8;
+
+contract B{
+}
+contract A is B{
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -159,4 +159,8 @@ describe('Solidity Merger', () => {
       assert.isOk(e);
     }
   });
+
+  it('should compile file without extra spaces before bracket in contract defininition', async () => {
+    await testFile('ContractWithoutSpaceBeforeBracket');
+  });
 });


### PR DESCRIPTION
When contact has no extra space between the is and start of the contract body the bracket is counting as the is part of the contact. For example:

`A is B{` the is clause will be `is B{` instead of `is B`

Closes #73